### PR TITLE
Add possibility of using extension filter in file dialogs

### DIFF
--- a/cvlab/diagram/parameters.py
+++ b/cvlab/diagram/parameters.py
@@ -60,9 +60,10 @@ class Parameter(QObject):
 class PathParameter(Parameter):
     base_path = None
 
-    def __init__(self, id, name=None, value="", save_mode=False, *args, **kwargs):
+    def __init__(self, id, name=None, value="", save_mode=False, extension_filter=None, *args, **kwargs):
         super(PathParameter, self).__init__(id, name, value, *args, **kwargs)
         self.save_mode = save_mode
+        self.extension_filter = extension_filter  # filter in form "FORMAT (*.ext1 *.ext2 ...)", eg. "IMG (*.jpg *.png)"
 
     def to_json(self):
         return self.to_json_relative(self.value)

--- a/cvlab/view/parameters.py
+++ b/cvlab/view/parameters.py
@@ -59,10 +59,16 @@ class GuiPathParameter(GuiBaseParameter):
 
     @pyqtSlot()
     def choose_path(self):
+        _filter = self.parameter.extension_filter
+        caption = _filter + " " if _filter is not None else ""
+
         if self.parameter.save_mode:
-            path, _ = QFileDialog.getSaveFileName(self.browse, "Save file...", self.parameter.get())
+            caption = "Save " + caption + "file..."
+            path, _ = QFileDialog.getSaveFileName(self.browse, caption,self.parameter.get(), _filter)
         else:
-            path, _ = QFileDialog.getOpenFileName(self.browse, "Open file...", self.parameter.get())
+            caption = "Open " + caption + "file..."
+            path, _ = QFileDialog.getOpenFileName(self.browse, caption, self.parameter.get(), _filter)
+
         self.set_path_(str(path))
 
 


### PR DESCRIPTION
Now when creating PathParameter (and all subclasses) object an extension_filter value can be specified
to do so pass a string formated like "FORMAT_NAME (*.ext1, *.ext2 ...)" eg. "IMAGE (*.jpg *.png)"