### PR TITLE
Fix limits for preview resizing

### DIFF
--- a/cvlab/view/widgets.py
+++ b/cvlab/view/widgets.py
@@ -165,8 +165,8 @@ Double click - open the preview in separate window"""
         event.accept()
 
     def resize_previews(self, new_size):
-        out_size = np.clip(int(new_size), 16, 2048)
-        self.preview_size = new_size
+        out_size = np.clip(int(new_size), 64, 2048)
+        self.preview_size = out_size
         for preview in self.previews:
             preview.preview_size = out_size
         self.update()


### PR DESCRIPTION
Now you can only change preview size with mouse wheel from 64 to 2048 px